### PR TITLE
Fixes for several typos and links to other pages.

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -42,7 +42,7 @@ The site has **topics**. The topics that are _published_ are in `_topics`. Each
 markdown file in there contains settings (in fact those files only contain
 Jekyll "front-matter").
 
-To **add a new topi**:
+To **add a new topic**:
 
 * add a markdown file to `_collections/_topics`
 * update the `_config.yml`: add the page you've just added  to the

--- a/collections/_command-line/tab-completion.md
+++ b/collections/_command-line/tab-completion.md
@@ -7,7 +7,7 @@ order: 119
 
 Although the command line interpreter does not attempt to execute the command
 until you have submitted it with enter, there are a few keys that have special
-purpose. One is the [tab key]({{ site.baseurl }}/keyboard/tab-key).
+purpose. One is the [tab key]({{ site.baseurl }}/keyboard/tab).
 
 If you start typing a command, and then press tab, the system will try to
 auto-complete the command it _thinks_ you are typing. If there are choices it

--- a/collections/_command-line/what-is-it.md
+++ b/collections/_command-line/what-is-it.md
@@ -5,7 +5,7 @@ order: 101
 ---
 
 
-The fundamental way of issuing a command to the the computer is by typing it on
+The fundamental way of issuing a command to the computer is by typing it on
 the _command line_.
 
 Interfaces (like point-and-click graphical interfaces, or audio commands, or

--- a/collections/_command-line/why.md
+++ b/collections/_command-line/why.md
@@ -46,8 +46,8 @@ works: it's possibly the primary way you communicate with the computer. The GUI
 is a layer on top of that (of course you will be familiar with that too).
 
 You can drive most computers from the command line. We tend to focus on the
-Unix-like systems (that includes the Mac's command line, and the Linux
-Subsystem for Windows) because they have a long history of utility, predating
+Unix-like systems (that includes the Mac's command line, and the Windows
+Subsystem for Linux) because they have a long history of utility, predating
 GUIs entirely. Window's own command line is a little bit different, but the
 underlying ideas are similar.
 

--- a/collections/_file-system/contents.md
+++ b/collections/_file-system/contents.md
@@ -8,7 +8,7 @@ What's in a file?
 
 When you save things to computer disk, the storage is organised by files.
 
-Your Python program to can be in a file. A JPEG image of your dog is a file.
+Your Python program can be in a file. A JPEG image of your dog is a file.
 An application might be in a file. A spreadsheet is a file.
 
 You need a basic appreciation of files in order to use a computer. The

--- a/collections/_file-system/directories.md
+++ b/collections/_file-system/directories.md
@@ -58,7 +58,7 @@ none, one, or many subdirectories.
 ---
 
 <sup id="footnote-1">1</sup>&nbsp;
-You can create [symbolic links]({site.baseurl}/file-system/symbolic-links)
+You can create [symbolic links]({{ site.baseurl }}/files/symlinks)
 that make it look as if a directory is in more than one place... but these
 are just aliases, so the directory itself still has only one parent.
 

--- a/collections/_file-system/names.md
+++ b/collections/_file-system/names.md
@@ -14,7 +14,7 @@ Every file has a name. These are examples of file names:
     letter.2020-12-03.docx
 
 The filename must be unique in the
-[directory]({{ site.baseurl }}/files/directory) it's inside.
+[directory]({{ site.baseurl }}/files/directories) it's inside.
 You cannot have two files with the same name within the same directory.
 
 You can give files almost any name you want... but it's a good idea to only

--- a/collections/_file-system/parent-directory.md
+++ b/collections/_file-system/parent-directory.md
@@ -7,7 +7,7 @@ order: 107
 Also known as: "the directory above".
 
 The parent of _any directory_ has the
-[special name]({{ site.baseurl}}/files/special-names) `..` (two dots).
+[special name]({{ site.baseurl}}/files/special-filenames) `..` (two dots).
 
 This is useful because you can include it in file paths without needing to 
 explicitly know the name of the parent.

--- a/collections/_file-system/paths.md
+++ b/collections/_file-system/paths.md
@@ -13,7 +13,7 @@ directory.
 The route is described by naming each of the directories, in order, through
 which you must pass to get to the directory that contains the file. The
 directory names are separated by the
-[path separator]({{ site.baseurl }}/files/path separator) character, which on
+[path separator]({{ site.baseurl }}/files/path-separators) character, which on
 Unix is `/` (and Windows is `\`).
 
 >  The file itself is identified by its filename. Remember that filenames are

--- a/collections/_keyboard/enter-key.md
+++ b/collections/_keyboard/enter-key.md
@@ -13,7 +13,7 @@ arrow like this:
 
 The enter key is often used to indicate the end of _submitting input_. You
 might already be used to using it to mean "go" or "send". See more about
-[using enter on the command line]({{ site.baseurl }}/command-line/using enter/) .
+[using enter on the command line]({{ site.baseurl }}/command-line/using-enter) .
 
 In word processors or text editors the enter key indicates a new line — this is
 really from the days of "carriage-return and new line" from typewriters. This

--- a/collections/_keyboard/windows-key.md
+++ b/collections/_keyboard/windows-key.md
@@ -12,5 +12,5 @@ system.
 When pressed alone, the Windows key brings up the Start menu.
 
 The Windows key is sometimes used as a 
-[modifier key]({{ base.siteurl }}/keyboard/modifier-key)
+[modifier key]({{ base.siteurl }}/keyboard/modifier-keys)
 for specific tasks in Windows applications.


### PR DESCRIPTION
Some links were linking to the wrong pages, i.e. tab-keys.md (doesn't exist) instead of tab.md. Other links had issues with spaces.

Tested the links that I updated and they seem to be working as expected now.